### PR TITLE
Add a connection welcome

### DIFF
--- a/app.go
+++ b/app.go
@@ -15,17 +15,18 @@ import (
 var port string
 var certFile, keyFile string
 var name string
+var banner bool
 
 func init() {
 	flag.StringVar(&port, "port", ":8080", "give me a port number")
 	flag.StringVar(&certFile, "certFile", "", "TLS - certificate path")
 	flag.StringVar(&keyFile, "keyFile", "", "TLS - key path")
 	flag.StringVar(&name, "name", "", "name")
+	flag.BoolVar(&banner, "banner", false, "Connection banner")
 }
 
 func main() {
 	flag.Parse()
-
 	fmt.Printf("Starting up on port %s", port)
 
 	var listener net.Listener
@@ -51,6 +52,9 @@ func main() {
 		conn, err := listener.Accept()
 		if err != nil {
 			log.Fatal(err)
+		}
+		if banner {
+			conn.Write([]byte("Welcome"))
 		}
 		go serveTCP(conn)
 	}

--- a/app.go
+++ b/app.go
@@ -56,8 +56,8 @@ func main() {
 		if banner {
 			_, err := conn.Write([]byte("Welcome"))
 			if err != nil {
-			    log.Fatal(err)
-			}			    
+				log.Fatal(err)
+			}
 
 		}
 		go serveTCP(conn)

--- a/app.go
+++ b/app.go
@@ -54,7 +54,11 @@ func main() {
 			log.Fatal(err)
 		}
 		if banner {
-			conn.Write([]byte("Welcome"))
+			_, err := conn.Write([]byte("Welcome"))
+			if err != nil {
+			    log.Fatal(err)
+			}			    
+
 		}
 		go serveTCP(conn)
 	}


### PR DESCRIPTION
With --banner option, you can add a welcome banner when the client connect to the whoami (even if the client didn't sent any bytes)